### PR TITLE
feat: add min total length config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 
 - `enable`: 是否启用插件 (默认: true)
 - `max_total_length`: 最大总文本长度限制 (默认: 3000字符)
+- `min_total_length`: 最小总文本长度限制 (默认: 200字符)
 - `segment_length`: 每段目标长度 (默认: 400字符)
 - `min_segments`: 最小分段数 (默认: 1)
 - `max_segments`: 最大分段数 (默认: 4)

--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,8 @@ enable = true
 
 # 最大总文本长度限制（字符数）
 max_total_length = 2400
+
+# 最小总文本长度限制（字符数）
 min_total_length = 200
 
 # 每段目标长度（字符数）

--- a/plugin.py
+++ b/plugin.py
@@ -360,6 +360,7 @@ class DetailedExplanationPlugin(BasePlugin):
         "detailed_explanation": {
             "enable": ConfigField(type=bool, default=True, description="是否启用详细解释功能"),
             "max_total_length": ConfigField(type=int, default=3000, description="最大总文本长度限制"),
+            "min_total_length": ConfigField(type=int, default=200, description="最小总文本长度限制"),
             "segment_length": ConfigField(type=int, default=400, description="每段目标长度"),
             "min_segments": ConfigField(type=int, default=1, description="最小分段数"),
             "max_segments": ConfigField(type=int, default=4, description="最大分段数"),


### PR DESCRIPTION
## Summary
- add `min_total_length` config field to enforce minimum text length
- document new `min_total_length` option in README and `config.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c6238da8b8832985781ddf53db3bb1