### PR TITLE
Respect max segment limit in smart splitting algorithm

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -220,11 +220,21 @@ class DetailedExplanationAction(BaseAction):
         segments = []
         current_segment = ""
         
-        for paragraph in paragraphs:
+        for idx, paragraph in enumerate(paragraphs):
             paragraph = paragraph.strip()
             if not paragraph:
                 continue
-                
+
+            # 如果已达到最大段数-1，将剩余内容合并为最后一段
+            if len(segments) >= max_segments - 1:
+                remaining_parts = []
+                if current_segment:
+                    remaining_parts.append(current_segment)
+                remaining_parts.extend(p.strip() for p in paragraphs[idx:] if p.strip())
+                segments.append("\n\n".join(remaining_parts))
+                current_segment = ""
+                break
+
             # 如果当前段落加上新段落不超过目标长度，合并
             if len(current_segment + paragraph) <= target_length:
                 if current_segment:
@@ -235,7 +245,7 @@ class DetailedExplanationAction(BaseAction):
                 # 如果当前段不为空，先保存
                 if current_segment:
                     segments.append(current_segment)
-                
+
                 # 如果单个段落太长，按句子分割
                 if len(paragraph) > target_length:
                     sentences = self._split_by_sentences(paragraph)
@@ -250,7 +260,7 @@ class DetailedExplanationAction(BaseAction):
                     current_segment = temp_segment
                 else:
                     current_segment = paragraph
-        
+
         # 添加最后一段
         if current_segment:
             segments.append(current_segment)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -79,3 +79,24 @@ def test_segment_merge_preserves_newlines():
     content = "A" * 10 + "B" * 10 + "C" * 10
     segments = action._split_content_into_segments(content)
     assert segments == ["A" * 10, "B" * 10 + "\n\n" + "C" * 10]
+
+
+class DummySmartAction(DetailedExplanationAction):
+    def __init__(self):
+        self.log_prefix = "test"
+
+    def get_config(self, key, default=None):
+        configs = {
+            "detailed_explanation.segment_length": 5,
+            "detailed_explanation.min_segments": 1,
+            "detailed_explanation.max_segments": 2,
+            "segmentation.algorithm": "smart",
+        }
+        return configs.get(key, default)
+
+
+def test_smart_split_respects_max_segments():
+    action = DummySmartAction()
+    content = "AAAA" + "\n\n" + "BBBB" + "\n\n" + "CCCC" + "\n\n" + "DDDD"
+    segments = action._split_content_into_segments(content)
+    assert segments == ["AAAA", "BBBB\n\nCCCC\n\nDDDD"]


### PR DESCRIPTION
## Summary
- Stop smart split loop once it would exceed the configured segment limit
- Add unit test validating smart split merges the remaining content when hitting the segment cap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c62387f36c8329aadbc93a0c6a2976