### PR TITLE
Ensure minimum segment splitting respects limits

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -196,12 +196,14 @@ class DetailedExplanationAction(BaseAction):
             
             # 确保段数在限制范围内
             if len(segments) < min_segments:
-                # 如果段数太少，尝试合并
-                return [content]
-            elif len(segments) > max_segments:
+                # 按最小分段数重新按长度划分
+                target_length = max(1, len(content) // min_segments)
+                segments = self._length_split(content, target_length, max_segments)
+
+            if len(segments) > max_segments:
                 # 如果段数太多，合并后面的段，并保留段落间的换行
-                tail = "\n\n".join(segments[max_segments-1:])
-                segments = segments[:max_segments-1] + [tail]
+                tail = "\n\n".join(segments[max_segments - 1:])
+                segments = segments[:max_segments - 1] + [tail]
             
             logger.info(f"{self.log_prefix} 内容分割完成，共{len(segments)}段")
             return segments

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -79,3 +79,24 @@ def test_segment_merge_preserves_newlines():
     content = "A" * 10 + "B" * 10 + "C" * 10
     segments = action._split_content_into_segments(content)
     assert segments == ["A" * 10, "B" * 10 + "\n\n" + "C" * 10]
+
+
+class DummyMinSegmentsAction(DetailedExplanationAction):
+    def __init__(self):
+        self.log_prefix = "test"
+
+    def get_config(self, key, default=None):
+        configs = {
+            "detailed_explanation.segment_length": 30,
+            "detailed_explanation.min_segments": 3,
+            "detailed_explanation.max_segments": 3,
+            "segmentation.algorithm": "length",
+        }
+        return configs.get(key, default)
+
+
+def test_resplit_when_below_min_segments():
+    action = DummyMinSegmentsAction()
+    content = "A" * 40
+    segments = action._split_content_into_segments(content)
+    assert segments == ["A" * 13, "A" * 13, "A" * 13 + "\n\n" + "A"]


### PR DESCRIPTION
## Summary
- Re-split content by length when initial segmentation yields too few segments
- Cap re-split segments at `max_segments`
- Test min-segment resplitting and newline merge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c623582c188329a3dd801dca5ceddd